### PR TITLE
Release v1.2.0 - Bens e Passivos

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   assets              Asset[]
   investmentEntries   InvestmentEntry[]
   journalEntries      JournalEntry[]
+  wealthItems         WealthItem[]
 }
 
 model Notification {
@@ -164,4 +165,22 @@ model JournalEntry {
   updatedAt                DateTime         @updatedAt
   user                     User             @relation(fields: [userId], references: [id], onDelete: Cascade)
   investmentEntry          InvestmentEntry? @relation(fields: [investmentEntryId], references: [id], onDelete: SetNull)
+}
+
+enum WealthItemType {
+  ASSET
+  LIABILITY
+}
+
+model WealthItem {
+  id        String         @id @default(cuid())
+  userId    String
+  name      String
+  value     Decimal        @db.Decimal(14, 2)
+  itemType  WealthItemType
+  category  String
+  notes     String?
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+  user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/app/api/patrimonio/items/[id]/route.ts
+++ b/src/app/api/patrimonio/items/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const body = await req.json();
+  const { name, value, category, notes } = body;
+
+  const item = await prisma.wealthItem.findUnique({ where: { id } });
+  if (!item || item.userId !== session.user.id) {
+    return NextResponse.json({ error: "Não encontrado" }, { status: 403 });
+  }
+
+  if (value !== undefined && (typeof value !== "number" || value <= 0)) {
+    return NextResponse.json({ error: "Valor deve ser maior que zero" }, { status: 400 });
+  }
+
+  const updated = await prisma.wealthItem.update({
+    where: { id },
+    data: {
+      ...(name && { name: name.trim() }),
+      ...(value !== undefined && { value }),
+      ...(category && { category: category.trim() }),
+      ...(notes !== undefined && { notes: notes?.trim() || null }),
+    },
+  });
+
+  return NextResponse.json({
+    id: updated.id,
+    name: updated.name,
+    value: parseFloat(String(updated.value)),
+    itemType: updated.itemType as "ASSET" | "LIABILITY",
+    category: updated.category,
+    notes: updated.notes,
+    createdAt: updated.createdAt.toISOString(),
+  });
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+
+  const item = await prisma.wealthItem.findUnique({ where: { id } });
+  if (!item || item.userId !== session.user.id) {
+    return NextResponse.json({ error: "Não encontrado" }, { status: 403 });
+  }
+
+  await prisma.wealthItem.delete({ where: { id } });
+  return NextResponse.json({}, { status: 204 });
+}

--- a/src/app/api/patrimonio/items/route.ts
+++ b/src/app/api/patrimonio/items/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export interface WealthItemSerialized {
+  id: string;
+  name: string;
+  value: number;
+  itemType: "ASSET" | "LIABILITY";
+  category: string;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface WealthItemsResponse {
+  items: WealthItemSerialized[];
+  totalAssets: number;
+  totalLiabilities: number;
+  net: number;
+}
+
+function serialize(item: {
+  id: string;
+  name: string;
+  value: unknown;
+  itemType: string;
+  category: string;
+  notes: string | null;
+  createdAt: Date;
+}): WealthItemSerialized {
+  return {
+    id: item.id,
+    name: item.name,
+    value: parseFloat(String(item.value)),
+    itemType: item.itemType as "ASSET" | "LIABILITY",
+    category: item.category,
+    notes: item.notes,
+    createdAt: item.createdAt.toISOString(),
+  };
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const rows = await prisma.wealthItem.findMany({
+    where: { userId: session.user.id },
+    orderBy: [{ itemType: "asc" }, { createdAt: "desc" }],
+  });
+
+  const items = rows.map(serialize);
+
+  const totalAssets = items
+    .filter((i) => i.itemType === "ASSET")
+    .reduce((acc, i) => acc + i.value, 0);
+
+  const totalLiabilities = items
+    .filter((i) => i.itemType === "LIABILITY")
+    .reduce((acc, i) => acc + i.value, 0);
+
+  return NextResponse.json({
+    items,
+    totalAssets,
+    totalLiabilities,
+    net: totalAssets - totalLiabilities,
+  } satisfies WealthItemsResponse);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const { name, value, itemType, category, notes } = body;
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "Nome é obrigatório" }, { status: 400 });
+  }
+  if (!value || typeof value !== "number" || value <= 0) {
+    return NextResponse.json({ error: "Valor deve ser maior que zero" }, { status: 400 });
+  }
+  if (itemType !== "ASSET" && itemType !== "LIABILITY") {
+    return NextResponse.json({ error: "Tipo inválido" }, { status: 400 });
+  }
+  if (!category || typeof category !== "string" || category.trim().length === 0) {
+    return NextResponse.json({ error: "Categoria é obrigatória" }, { status: 400 });
+  }
+
+  const item = await prisma.wealthItem.create({
+    data: {
+      userId: session.user.id,
+      name: name.trim(),
+      value,
+      itemType,
+      category: category.trim(),
+      notes: notes?.trim() || null,
+    },
+  });
+
+  return NextResponse.json(serialize(item), { status: 201 });
+}

--- a/src/components/patrimonio/PatrimonioShell.tsx
+++ b/src/components/patrimonio/PatrimonioShell.tsx
@@ -6,9 +6,11 @@ import { SavingsRateChart } from "@/components/reports/patrimonio/SavingsRateCha
 import { FireProjection } from "@/components/reports/patrimonio/FireProjection";
 import { AssetBreakdown } from "./AssetBreakdown";
 import { BenchmarkComparison } from "./BenchmarkComparison";
+import { WealthItems } from "./WealthItems";
 import { PatrimonioGoal } from "./PatrimonioGoal";
 import type { NetworthData } from "@/components/reports/types";
 import type { BenchmarkData } from "@/lib/benchmarks";
+import type { WealthItemsResponse } from "@/app/api/patrimonio/items/route";
 
 interface PortfolioTotals {
   totalCurrentValue: number;
@@ -46,6 +48,9 @@ export function PatrimonioShell({ initialCurrency, initialLocale }: PatrimonioSh
   const [goalData, setGoalData] = useState<{ goal: number | null } | null>(null);
   const [goalLoading, setGoalLoading] = useState(false);
 
+  const [itemsData, setItemsData] = useState<WealthItemsResponse | null>(null);
+  const [itemsLoading, setItemsLoading] = useState(false);
+
   const fetchGoal = useCallback(async () => {
     setGoalLoading(true);
     try {
@@ -58,17 +63,31 @@ export function PatrimonioShell({ initialCurrency, initialLocale }: PatrimonioSh
     }
   }, []);
 
+  const fetchItems = useCallback(async () => {
+    setItemsLoading(true);
+    try {
+      const res = await fetch("/api/patrimonio/items");
+      if (res.ok) setItemsData(await res.json());
+    } catch {
+      // silent
+    } finally {
+      setItemsLoading(false);
+    }
+  }, []);
+
   const fetchData = useCallback(async () => {
     setLoading(true);
     setPortfolioLoading(true);
     setBenchmarksLoading(true);
     setGoalLoading(true);
+    setItemsLoading(true);
 
-    const [networthRes, portfolioRes, benchmarksRes, goalRes] = await Promise.allSettled([
+    const [networthRes, portfolioRes, benchmarksRes, goalRes, itemsRes] = await Promise.allSettled([
       fetch("/api/reports/networth"),
       fetch("/api/investments/portfolio"),
       fetch("/api/investments/benchmarks"),
       fetch("/api/patrimonio/goal"),
+      fetch("/api/patrimonio/items"),
     ]);
 
     if (networthRes.status === "fulfilled" && networthRes.value.ok) {
@@ -90,6 +109,11 @@ export function PatrimonioShell({ initialCurrency, initialLocale }: PatrimonioSh
       setGoalData(await goalRes.value.json());
     }
     setGoalLoading(false);
+
+    if (itemsRes.status === "fulfilled" && itemsRes.value.ok) {
+      setItemsData(await itemsRes.value.json());
+    }
+    setItemsLoading(false);
   }, []);
 
   useEffect(() => {
@@ -102,6 +126,9 @@ export function PatrimonioShell({ initialCurrency, initialLocale }: PatrimonioSh
       ? data.months.reduce((acc, m) => acc + (m.monthIncome - m.monthExpenses), 0) /
         data.months.length
       : 0;
+
+  // Patrimônio ajustado: transações + bens - passivos
+  const adjustedNetWorth = (data?.currentNetWorth ?? 0) + (itemsData?.net ?? 0);
 
   return (
     <div className="flex flex-col gap-6">
@@ -132,7 +159,7 @@ export function PatrimonioShell({ initialCurrency, initialLocale }: PatrimonioSh
         </div>
       )}
 
-      {/* Novos componentes v1.1 */}
+      {/* AssetBreakdown */}
       {portfolioLoading ? (
         <SkeletonCard label="Breakdown por Classe de Ativo" />
       ) : (
@@ -144,7 +171,8 @@ export function PatrimonioShell({ initialCurrency, initialLocale }: PatrimonioSh
         />
       )}
 
-      {(loading || benchmarksLoading) ? (
+      {/* BenchmarkComparison */}
+      {loading || benchmarksLoading ? (
         <SkeletonCard label="Comparação vs Benchmark" />
       ) : data ? (
         <BenchmarkComparison
@@ -156,11 +184,27 @@ export function PatrimonioShell({ initialCurrency, initialLocale }: PatrimonioSh
         />
       ) : null}
 
+      {/* Bens e Passivos */}
+      {itemsLoading ? (
+        <SkeletonCard label="Bens e Passivos" />
+      ) : (
+        <WealthItems
+          items={itemsData?.items ?? []}
+          totalAssets={itemsData?.totalAssets ?? 0}
+          totalLiabilities={itemsData?.totalLiabilities ?? 0}
+          net={itemsData?.net ?? 0}
+          currency={initialCurrency}
+          locale={initialLocale}
+          onRefresh={fetchItems}
+        />
+      )}
+
+      {/* Meta de Patrimônio — usa adjustedNetWorth */}
       {goalLoading ? (
         <SkeletonCard label="Meta de Patrimônio" />
       ) : (
         <PatrimonioGoal
-          currentNetWorth={data?.currentNetWorth ?? 0}
+          currentNetWorth={adjustedNetWorth}
           goal={goalData?.goal ?? null}
           avgMonthlySavings={avgMonthlySavings}
           currency={initialCurrency}

--- a/src/components/patrimonio/WealthItemDialog.tsx
+++ b/src/components/patrimonio/WealthItemDialog.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState, FormEvent, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import type { WealthItemSerialized } from "@/app/api/patrimonio/items/route";
+
+const ASSET_CATEGORIES = [
+  "Imóvel",
+  "Veículo",
+  "Investimento Externo",
+  "Conta Bancária",
+  "Previdência",
+  "Outro",
+];
+
+const LIABILITY_CATEGORIES = [
+  "Financiamento Imobiliário",
+  "Financiamento Veicular",
+  "Empréstimo Pessoal",
+  "Cartão de Crédito",
+  "Outro",
+];
+
+interface WealthItemDialogProps {
+  mode: "create" | "edit";
+  defaultType?: "ASSET" | "LIABILITY";
+  item?: WealthItemSerialized;
+  onSuccess: (item: WealthItemSerialized) => void;
+  onClose: () => void;
+}
+
+export function WealthItemDialog({
+  mode,
+  defaultType = "ASSET",
+  item,
+  onSuccess,
+  onClose,
+}: WealthItemDialogProps) {
+  const [name, setName] = useState(item?.name ?? "");
+  const [value, setValue] = useState(item?.value?.toString() ?? "");
+  const [itemType, setItemType] = useState<"ASSET" | "LIABILITY">(
+    item?.itemType ?? defaultType
+  );
+  const [category, setCategory] = useState(
+    item?.category ?? (defaultType === "ASSET" ? ASSET_CATEGORIES[0] : LIABILITY_CATEGORIES[0])
+  );
+  const [notes, setNotes] = useState(item?.notes ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync state when item changes (edit mode)
+  useEffect(() => {
+    if (item) {
+      setName(item.name);
+      setValue(item.value.toString());
+      setItemType(item.itemType);
+      setCategory(item.category);
+      setNotes(item.notes ?? "");
+    }
+  }, [item]);
+
+  function handleTypeChange(type: "ASSET" | "LIABILITY") {
+    setItemType(type);
+    setCategory(type === "ASSET" ? ASSET_CATEGORIES[0] : LIABILITY_CATEGORIES[0]);
+  }
+
+  const presets = itemType === "ASSET" ? ASSET_CATEGORIES : LIABILITY_CATEGORIES;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const parsedValue = parseFloat(value.replace(",", "."));
+    if (!name.trim()) {
+      setError("Nome é obrigatório");
+      return;
+    }
+    if (isNaN(parsedValue) || parsedValue <= 0) {
+      setError("Valor deve ser maior que zero");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const url =
+        mode === "create"
+          ? "/api/patrimonio/items"
+          : `/api/patrimonio/items/${item!.id}`;
+      const method = mode === "create" ? "POST" : "PATCH";
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          value: parsedValue,
+          ...(mode === "create" && { itemType }),
+          category,
+          notes: notes.trim() || null,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Erro ao salvar. Tente novamente.");
+        return;
+      }
+
+      onSuccess(data);
+    } catch {
+      setError("Erro de conexão. Tente novamente.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="bg-axiom-card border-axiom-border text-white max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-white">
+            {mode === "create"
+              ? itemType === "ASSET"
+                ? "Adicionar Ativo"
+                : "Adicionar Passivo"
+              : "Editar Item"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Tipo */}
+          <div className="space-y-1.5">
+            <Label className="text-axiom-muted text-sm">Tipo</Label>
+            <Select
+              value={itemType}
+              onValueChange={(v) => handleTypeChange(v as "ASSET" | "LIABILITY")}
+              disabled={mode === "edit"}
+            >
+              <SelectTrigger className="bg-axiom-hover border-axiom-border text-white focus:border-axiom-primary">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="bg-axiom-card border-axiom-border">
+                <SelectItem value="ASSET" className="text-white hover:bg-axiom-hover focus:bg-axiom-hover">
+                  Ativo
+                </SelectItem>
+                <SelectItem value="LIABILITY" className="text-white hover:bg-axiom-hover focus:bg-axiom-hover">
+                  Passivo
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Nome */}
+          <div className="space-y-1.5">
+            <Label htmlFor="wealth-name" className="text-axiom-muted text-sm">Nome</Label>
+            <Input
+              id="wealth-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="bg-axiom-hover border-axiom-border text-white focus:border-axiom-primary"
+              placeholder={itemType === "ASSET" ? "Ex: Apartamento Centro" : "Ex: Financiamento Caixa"}
+            />
+          </div>
+
+          {/* Valor */}
+          <div className="space-y-1.5">
+            <Label htmlFor="wealth-value" className="text-axiom-muted text-sm">Valor atual (R$)</Label>
+            <Input
+              id="wealth-value"
+              type="number"
+              min="0.01"
+              step="0.01"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              className="bg-axiom-hover border-axiom-border text-white focus:border-axiom-primary"
+              placeholder="0,00"
+            />
+          </div>
+
+          {/* Categoria */}
+          <div className="space-y-1.5">
+            <Label className="text-axiom-muted text-sm">Categoria</Label>
+            <Select value={category} onValueChange={(v) => setCategory(v ?? presets[0])}>
+              <SelectTrigger className="bg-axiom-hover border-axiom-border text-white focus:border-axiom-primary">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="bg-axiom-card border-axiom-border">
+                {presets.map((p) => (
+                  <SelectItem
+                    key={p}
+                    value={p}
+                    className="text-white hover:bg-axiom-hover focus:bg-axiom-hover"
+                  >
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Notas */}
+          <div className="space-y-1.5">
+            <Label htmlFor="wealth-notes" className="text-axiom-muted text-sm">
+              Notas <span className="text-axiom-muted/60">(opcional)</span>
+            </Label>
+            <textarea
+              id="wealth-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={3}
+              placeholder="Observações adicionais..."
+              className="bg-axiom-hover border border-axiom-border rounded-lg px-3 py-2 text-white text-sm placeholder:text-axiom-muted focus:outline-none focus:border-axiom-primary w-full resize-none"
+            />
+          </div>
+
+          {error && <p className="text-axiom-expense text-sm">{error}</p>}
+
+          <DialogFooter className="gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              className="border-axiom-border text-axiom-muted hover:text-white hover:bg-axiom-hover"
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={saving}
+              className="bg-axiom-primary hover:bg-axiom-primary/90 text-white"
+            >
+              {saving ? "Salvando..." : mode === "create" ? "Adicionar" : "Salvar"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/patrimonio/WealthItems.tsx
+++ b/src/components/patrimonio/WealthItems.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState } from "react";
+import { TrendingUp, TrendingDown, Pencil, Trash2, Plus } from "lucide-react";
+import { WealthItemDialog } from "./WealthItemDialog";
+import { formatCurrency } from "@/lib/utils";
+import type { WealthItemSerialized } from "@/app/api/patrimonio/items/route";
+
+interface WealthItemsProps {
+  items: WealthItemSerialized[];
+  totalAssets: number;
+  totalLiabilities: number;
+  net: number;
+  currency: string;
+  locale: string;
+  onRefresh: () => void;
+}
+
+export function WealthItems({
+  items,
+  totalAssets,
+  totalLiabilities,
+  net,
+  currency,
+  locale,
+  onRefresh,
+}: WealthItemsProps) {
+  const [dialogMode, setDialogMode] = useState<"create" | "edit" | null>(null);
+  const [editingItem, setEditingItem] = useState<WealthItemSerialized | null>(null);
+  const [defaultType, setDefaultType] = useState<"ASSET" | "LIABILITY">("ASSET");
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  function openCreate(type: "ASSET" | "LIABILITY") {
+    setDefaultType(type);
+    setEditingItem(null);
+    setDialogMode("create");
+  }
+
+  function openEdit(item: WealthItemSerialized) {
+    setEditingItem(item);
+    setDialogMode("edit");
+  }
+
+  function closeDialog() {
+    setDialogMode(null);
+    setEditingItem(null);
+  }
+
+  function handleSuccess() {
+    closeDialog();
+    onRefresh();
+  }
+
+  async function handleDelete(id: string) {
+    setDeletingId(id);
+    try {
+      await fetch(`/api/patrimonio/items/${id}`, { method: "DELETE" });
+      onRefresh();
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  const assets = items.filter((i) => i.itemType === "ASSET");
+  const liabilities = items.filter((i) => i.itemType === "LIABILITY");
+
+  return (
+    <>
+      <div className="bg-axiom-card border border-axiom-border rounded-xl p-6 flex flex-col gap-5">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div>
+            <h3 className="text-sm font-semibold text-white">Bens e Passivos</h3>
+            <p className="text-xs text-axiom-muted mt-0.5">Patrimônio além das transações</p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => openCreate("ASSET")}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-axiom-income/10 border border-axiom-income/20 text-axiom-income text-xs font-medium hover:bg-axiom-income/20 transition-colors"
+            >
+              <Plus size={12} />
+              Ativo
+            </button>
+            <button
+              onClick={() => openCreate("LIABILITY")}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-axiom-expense/10 border border-axiom-expense/20 text-axiom-expense text-xs font-medium hover:bg-axiom-expense/20 transition-colors"
+            >
+              <Plus size={12} />
+              Passivo
+            </button>
+          </div>
+        </div>
+
+        {/* Summary bar */}
+        <div className="grid grid-cols-3 gap-3">
+          <div className="flex flex-col gap-0.5 p-3 rounded-lg bg-axiom-hover">
+            <span className="text-xs text-axiom-muted">Ativos</span>
+            <span className="text-sm font-bold text-axiom-income">
+              {formatCurrency(totalAssets, locale, currency)}
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5 p-3 rounded-lg bg-axiom-hover">
+            <span className="text-xs text-axiom-muted">Passivos</span>
+            <span className="text-sm font-bold text-axiom-expense">
+              {formatCurrency(totalLiabilities, locale, currency)}
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5 p-3 rounded-lg bg-axiom-hover">
+            <span className="text-xs text-axiom-muted">Líquido</span>
+            <span
+              className={`text-sm font-bold ${net >= 0 ? "text-axiom-income" : "text-axiom-expense"}`}
+            >
+              {formatCurrency(net, locale, currency)}
+            </span>
+          </div>
+        </div>
+
+        {/* Empty state */}
+        {items.length === 0 && (
+          <div className="flex flex-col items-center justify-center gap-3 py-8">
+            <p className="text-sm text-axiom-muted italic">Nenhum bem ou passivo cadastrado</p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => openCreate("ASSET")}
+                className="px-3 py-1.5 rounded-lg bg-axiom-primary text-white text-xs font-medium hover:bg-axiom-primary/90 transition-colors"
+              >
+                + Adicionar bem
+              </button>
+              <button
+                onClick={() => openCreate("LIABILITY")}
+                className="px-3 py-1.5 rounded-lg bg-axiom-hover border border-axiom-border text-axiom-muted text-xs hover:text-white transition-colors"
+              >
+                + Adicionar passivo
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Lista de Ativos */}
+        {assets.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 text-axiom-income">
+              <TrendingUp size={14} />
+              <span className="text-xs font-semibold uppercase tracking-wide">Ativos</span>
+            </div>
+            <div className="flex flex-col gap-1">
+              {assets.map((item) => (
+                <ItemRow
+                  key={item.id}
+                  item={item}
+                  locale={locale}
+                  currency={currency}
+                  deleting={deletingId === item.id}
+                  onEdit={() => openEdit(item)}
+                  onDelete={() => handleDelete(item.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Lista de Passivos */}
+        {liabilities.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 text-axiom-expense">
+              <TrendingDown size={14} />
+              <span className="text-xs font-semibold uppercase tracking-wide">Passivos</span>
+            </div>
+            <div className="flex flex-col gap-1">
+              {liabilities.map((item) => (
+                <ItemRow
+                  key={item.id}
+                  item={item}
+                  locale={locale}
+                  currency={currency}
+                  deleting={deletingId === item.id}
+                  onEdit={() => openEdit(item)}
+                  onDelete={() => handleDelete(item.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Dialog */}
+      {dialogMode && (
+        <WealthItemDialog
+          mode={dialogMode}
+          defaultType={defaultType}
+          item={editingItem ?? undefined}
+          onSuccess={handleSuccess}
+          onClose={closeDialog}
+        />
+      )}
+    </>
+  );
+}
+
+function ItemRow({
+  item,
+  locale,
+  currency,
+  deleting,
+  onEdit,
+  onDelete,
+}: {
+  item: WealthItemSerialized;
+  locale: string;
+  currency: string;
+  deleting: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg hover:bg-axiom-hover group transition-colors">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-sm text-white truncate">{item.name}</span>
+        <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] bg-axiom-hover text-axiom-muted border border-axiom-border">
+          {item.category}
+        </span>
+        {item.notes && (
+          <span className="text-[10px] text-axiom-muted/60 truncate hidden sm:block" title={item.notes}>
+            {item.notes}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <span
+          className={`text-sm font-semibold ${item.itemType === "ASSET" ? "text-axiom-income" : "text-axiom-expense"}`}
+        >
+          {item.itemType === "LIABILITY" ? "−" : ""}
+          {formatCurrency(item.value, locale, currency)}
+        </span>
+        <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            onClick={onEdit}
+            className="p-1 rounded text-axiom-muted hover:text-white transition-colors"
+            title="Editar"
+          >
+            <Pencil size={12} />
+          </button>
+          <button
+            onClick={onDelete}
+            disabled={deleting}
+            className="p-1 rounded text-axiom-muted hover:text-axiom-expense transition-colors disabled:opacity-50"
+            title="Remover"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Release v1.2.0 - Bens e Passivos

### Resumo
Cadastro de bens e passivos dentro de `/patrimonio`. O patrimônio líquido ajustado agora considera transações + bens − passivos, refletindo o valor real na meta de independência financeira.

### Issues Incluídas
- #85 Schema — WealthItem + WealthItemType enum
- #86 API GET + POST `/api/patrimonio/items`
- #87 API PATCH + DELETE `/api/patrimonio/items/[id]`
- #88 WealthItemDialog — dialog criar/editar bem ou passivo
- #89 WealthItems — lista agrupada com CRUD inline
- #90 PatrimonioShell — integração completa + adjustedNetWorth

### Funcionalidades
- Cadastro de ativos (Imóvel, Veículo, Investimento Externo, Conta Bancária, Previdência, Outro)
- Cadastro de passivos (Financiamento Imobiliário, Financiamento Veicular, Empréstimo Pessoal, Cartão de Crédito, Outro)
- Cada item tem: nome, valor atual, categoria, notas opcionais
- Resumo: total ativos / total passivos / líquido
- Lista agrupada por tipo com edição e exclusão inline
- `adjustedNetWorth = transações + (ativos − passivos)` usado na Meta de Patrimônio

🤖 Generated with [Claude Code](https://claude.com/claude-code)