### PR TITLE
Release v1.8.2 — fixes pós-release + deploy Vercel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,7 @@ A moeda padrão do usuário vem de `UserCurrency` com `isDefault: true`. O dashb
 | v1.5 | Bens & Passivos Aprimorado | ✅ concluída |
 | v1.6 | FIRE Dashboard: Independência Financeira | ✅ concluída — release v1.6.0 |
 | v1.7 | Independência Financeira Evoluída | ✅ concluída |
-| v1.8 | FIRE: Plano Real de Independência | ✅ concluída — release v1.8.0 |
+| v1.8 | FIRE: Plano Real de Independência | ✅ concluída — release v1.8.1 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "postinstall": "prisma generate"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/src/app/api/patrimonio/fire-settings/route.ts
+++ b/src/app/api/patrimonio/fire-settings/route.ts
@@ -2,15 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
-export interface FireSettingsResponse {
-  monthlyExpense: number | null;
-  swr: number | null;
-  targetMonthlyIncome: number | null;
-  retirementYears: number | null;
-  targetMonthlyContrib: number | null;
-  targetInvestedAmount: number | null;
-  fiNumberManual: number | null;
-}
+import type { FireSettingsResponse } from "@/types/fire";
+export type { FireSettingsResponse };
 
 export async function GET() {
   const session = await auth();

--- a/src/app/api/patrimonio/goals/route.ts
+++ b/src/app/api/patrimonio/goals/route.ts
@@ -2,17 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
-export interface FinancialGoalSerialized {
-  id: string;
-  name: string;
-  targetAmount: number;
-  savedAmount: number;
-  contributionAmount: number;
-  contributionFrequency: "DAILY" | "WEEKLY" | "MONTHLY";
-  bank: string | null;
-  notes: string | null;
-  createdAt: string;
-}
+import type { FinancialGoalSerialized } from "@/types/fire";
+export type { FinancialGoalSerialized };
 
 function serialize(goal: {
   id: string;

--- a/src/app/api/patrimonio/items/route.ts
+++ b/src/app/api/patrimonio/items/route.ts
@@ -3,32 +3,8 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { calcCurrentValue } from "@/lib/wealthCalc";
 
-export interface WealthItemSerialized {
-  id: string;
-  name: string;
-  value: number;             // valor atual calculado (base * (1+rate)^anos)
-  baseValue: number;         // valor original (para o formulário de edição)
-  itemType: "ASSET" | "LIABILITY";
-  category: string;
-  appreciationRate: number | null; // % a.a. (+6 = valoriza, -10 = deprecia)
-  appreciationStart: string;       // ISO date — ponto de partida do cálculo
-  rateFrequency: "MONTHLY" | "ANNUAL";
-  loanBank: string | null;
-  loanInstallments: number | null;
-  loanStartDate: string | null;
-  loanDueDay: number | null;
-  linkedCategoryId: string | null;
-  linkedCategoryName: string | null;
-  notes: string | null;
-  createdAt: string;
-}
-
-export interface WealthItemsResponse {
-  items: WealthItemSerialized[];
-  totalAssets: number;
-  totalLiabilities: number;
-  net: number;
-}
+import type { WealthItemSerialized, WealthItemsResponse } from "@/types/fire";
+export type { WealthItemSerialized, WealthItemsResponse };
 
 function serialize(item: {
   id: string;

--- a/src/app/api/reports/fire-essentials/route.ts
+++ b/src/app/api/reports/fire-essentials/route.ts
@@ -2,23 +2,8 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
-export interface FireEssentialsResponse {
-  categories: {
-    id: string;
-    name: string;
-    color: string;
-    monthlyAvg: number;
-  }[];
-  totalEssentialMonthly: number;
-  liabilityCosts: {
-    wealthItemId: string;
-    wealthItemName: string;
-    categoryId: string;
-    categoryName: string;
-    categoryColor: string;
-    monthlyAvg: number;
-  }[];
-}
+import type { FireEssentialsResponse } from "@/types/fire";
+export type { FireEssentialsResponse };
 
 export async function GET() {
   const session = await auth();

--- a/src/app/api/reports/fire/route.ts
+++ b/src/app/api/reports/fire/route.ts
@@ -6,29 +6,8 @@ const DEFAULT_RATES = {
   agressivo: 0.10,
 } as const;
 
-export interface FireScenario {
-  rate: number;
-  projectedMonths: number | null;
-  projectedYear: number | null;
-  projectionSeries: { month: number; value: number }[];
-}
-
-export interface FireResponse {
-  projectable: boolean;
-  reason?: string;
-  fiNumber?: number;
-  coastFireNumber?: number;
-  scenarios?: {
-    conservador: FireScenario;
-    moderado: FireScenario;
-    agressivo: FireScenario;
-  };
-  fiLine?: { month: number; value: number }[];
-  // Legacy fields (alias de moderado) — backward compat
-  projectedMonths?: number | null;
-  projectedYear?: number | null;
-  projectionSeries?: { month: number; value: number }[];
-}
+import type { FireScenario, FireResponse } from "@/types/fire";
+export type { FireScenario, FireResponse };
 
 function runScenario(
   patrimony: number,

--- a/src/components/patrimonio/FireDashboard.tsx
+++ b/src/components/patrimonio/FireDashboard.tsx
@@ -10,11 +10,13 @@ import { FirePlanCard } from "./FirePlanCard";
 import { FireMetricsCard } from "./FireMetricsCard";
 import { GoalCard } from "./GoalCard";
 import type { NetworthData } from "@/components/reports/types";
-import type { WealthItemsResponse } from "@/app/api/patrimonio/items/route";
-import type { FireSettingsResponse } from "@/app/api/patrimonio/fire-settings/route";
-import type { FireResponse } from "@/app/api/reports/fire/route";
-import type { FireEssentialsResponse } from "@/app/api/reports/fire-essentials/route";
-import type { FinancialGoalSerialized } from "@/app/api/patrimonio/goals/route";
+import type {
+  WealthItemsResponse,
+  FireSettingsResponse,
+  FireResponse,
+  FireEssentialsResponse,
+  FinancialGoalSerialized,
+} from "@/types/fire";
 
 interface PortfolioTotals {
   totalCurrentValue: number;

--- a/src/components/patrimonio/FireGoalsCard.tsx
+++ b/src/components/patrimonio/FireGoalsCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { formatCurrency } from "@/lib/utils";
-import type { FireSettingsResponse } from "@/app/api/patrimonio/fire-settings/route";
+import type { FireSettingsResponse } from "@/types/fire";
 
 interface FireGoalsCardProps {
   settings: FireSettingsResponse;

--- a/src/components/patrimonio/FirePlanCard.tsx
+++ b/src/components/patrimonio/FirePlanCard.tsx
@@ -30,7 +30,7 @@ export function FirePlanCard({
         <p className="text-xs text-axiom-muted mt-2">
           Marque categorias como{" "}
           <span className="text-axiom-primary font-medium">Essencial</span> em{" "}
-          <strong className="text-white">Configurações &gt; Categorias</strong> para ver o breakdown
+          <strong className="text-white">Transações &gt; Categorias</strong> para ver o breakdown
           do seu custo de vida real.
         </p>
       </div>

--- a/src/components/patrimonio/FireProjectionChart.tsx
+++ b/src/components/patrimonio/FireProjectionChart.tsx
@@ -13,7 +13,7 @@ import {
 } from "chart.js";
 import { Line } from "react-chartjs-2";
 import { formatCurrency } from "@/lib/utils";
-import type { FireScenario } from "@/app/api/reports/fire/route";
+import type { FireScenario } from "@/types/fire";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend, Filler);
 

--- a/src/components/patrimonio/GoalCard.tsx
+++ b/src/components/patrimonio/GoalCard.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Pencil, Trash2 } from "lucide-react";
 import { formatCurrency } from "@/lib/utils";
 import { getBankProductById, effectiveAnnualYield, monthsToReachGoal } from "@/lib/brazilianBanks";
-import type { FinancialGoalSerialized } from "@/app/api/patrimonio/goals/route";
+import type { FinancialGoalSerialized } from "@/types/fire";
 
 const FREQUENCY_LABELS: Record<string, string> = {
   DAILY: "Diário",

--- a/src/components/patrimonio/GoalDialog.tsx
+++ b/src/components/patrimonio/GoalDialog.tsx
@@ -21,7 +21,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import type { FinancialGoalSerialized } from "@/app/api/patrimonio/goals/route";
+import type { FinancialGoalSerialized } from "@/types/fire";
 import { getBankGroups } from "@/lib/brazilianBanks";
 
 interface GoalDialogProps {

--- a/src/components/patrimonio/GoalsList.tsx
+++ b/src/components/patrimonio/GoalsList.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { GoalCard } from "./GoalCard";
 import { GoalDialog } from "./GoalDialog";
-import type { FinancialGoalSerialized } from "@/app/api/patrimonio/goals/route";
+import type { FinancialGoalSerialized } from "@/types/fire";
 
 function SkeletonCard({ label }: { label: string }) {
   return (

--- a/src/components/patrimonio/PatrimonioShell.tsx
+++ b/src/components/patrimonio/PatrimonioShell.tsx
@@ -8,8 +8,8 @@ import { PortfolioPerformanceChart } from "./PortfolioPerformanceChart";
 import { WealthItems } from "./WealthItems";
 import { GoalsList } from "./GoalsList";
 import type { NetworthData } from "@/components/reports/types";
-import type { WealthItemsResponse } from "@/app/api/patrimonio/items/route";
-import type { FireEssentialsResponse } from "@/app/api/reports/fire-essentials/route";
+import type { WealthItemsResponse } from "@/types/fire";
+import type { FireEssentialsResponse } from "@/types/fire";
 
 type PatrimonioTab = "evolucao" | "analise" | "bens" | "meta";
 

--- a/src/components/patrimonio/WealthItemDialog.tsx
+++ b/src/components/patrimonio/WealthItemDialog.tsx
@@ -21,7 +21,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import type { WealthItemSerialized } from "@/app/api/patrimonio/items/route";
+import type { WealthItemSerialized } from "@/types/fire";
 import { formatCurrency } from "@/lib/utils";
 import { getLoanBankGroups, getLoanBankById } from "@/lib/loanBanks";
 

--- a/src/components/patrimonio/WealthItems.tsx
+++ b/src/components/patrimonio/WealthItems.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { TrendingUp, TrendingDown, Pencil, Trash2, Plus } from "lucide-react";
 import { WealthItemDialog } from "./WealthItemDialog";
 import { formatCurrency } from "@/lib/utils";
-import type { WealthItemSerialized } from "@/app/api/patrimonio/items/route";
+import type { WealthItemSerialized } from "@/types/fire";
 import type { InstallmentSerialized, InstallmentStatusResponse } from "@/app/api/patrimonio/items/[id]/installments/route";
 import { getLoanBankById } from "@/lib/loanBanks";
 import { calcLateFees, overdueMonths } from "@/lib/wealthCalc";
@@ -17,6 +17,8 @@ interface WealthItemsProps {
   currency: string;
   locale: string;
   onRefresh: () => void;
+  liabilityCosts?: { wealthItemId: string; monthlyAvg: number; categoryName: string }[];
+  userCategories?: { id: string; name: string; color: string }[];
 }
 
 export function WealthItems({
@@ -27,6 +29,8 @@ export function WealthItems({
   currency,
   locale,
   onRefresh,
+  liabilityCosts = [],
+  userCategories = [],
 }: WealthItemsProps) {
   const [dialogMode, setDialogMode] = useState<"create" | "edit" | null>(null);
   const [editingItem, setEditingItem] = useState<WealthItemSerialized | null>(null);
@@ -170,17 +174,21 @@ export function WealthItems({
               <span className="text-xs font-semibold uppercase tracking-wide">Passivos</span>
             </div>
             <div className="flex flex-col gap-1">
-              {liabilities.map((item) => (
-                <ItemRow
-                  key={item.id}
-                  item={item}
-                  locale={locale}
-                  currency={currency}
-                  deleting={deletingId === item.id}
-                  onEdit={() => openEdit(item)}
-                  onDelete={() => handleDelete(item.id)}
-                />
-              ))}
+              {liabilities.map((item) => {
+                const cost = liabilityCosts.find((c) => c.wealthItemId === item.id);
+                return (
+                  <ItemRow
+                    key={item.id}
+                    item={item}
+                    locale={locale}
+                    currency={currency}
+                    deleting={deletingId === item.id}
+                    onEdit={() => openEdit(item)}
+                    onDelete={() => handleDelete(item.id)}
+                    monthlyCost={cost}
+                  />
+                );
+              })}
             </div>
           </div>
         )}
@@ -192,6 +200,7 @@ export function WealthItems({
           mode={dialogMode}
           defaultType={defaultType}
           item={editingItem ?? undefined}
+          userCategories={userCategories}
           onSuccess={handleSuccess}
           onClose={closeDialog}
         />
@@ -207,6 +216,7 @@ function ItemRow({
   deleting,
   onEdit,
   onDelete,
+  monthlyCost,
 }: {
   item: WealthItemSerialized;
   locale: string;
@@ -214,6 +224,7 @@ function ItemRow({
   deleting: boolean;
   onEdit: () => void;
   onDelete: () => void;
+  monthlyCost?: { monthlyAvg: number; categoryName: string };
 }) {
   const hasDrift = item.appreciationRate && item.value !== item.baseValue;
   const gain = item.value - item.baseValue;
@@ -228,6 +239,11 @@ function ItemRow({
           <span className="shrink-0 px-1.5 py-0.5 rounded text-xs bg-axiom-hover text-axiom-muted border border-axiom-border">
             {item.category}
           </span>
+          {monthlyCost && monthlyCost.monthlyAvg > 0 && (
+            <span className="shrink-0 px-1.5 py-0.5 rounded text-xs bg-axiom-expense/10 border border-axiom-expense/20 text-axiom-expense">
+              ~{formatCurrency(monthlyCost.monthlyAvg, locale, currency)}/mês
+            </span>
+          )}
           {/* Badge de taxa de correção */}
           {item.appreciationRate ? (
             <span

--- a/src/types/fire.ts
+++ b/src/types/fire.ts
@@ -1,0 +1,97 @@
+// Type-only file — no server-only imports
+// Shared between client components and API routes
+
+export interface FireSettingsResponse {
+  monthlyExpense: number | null;
+  swr: number | null;
+  targetMonthlyIncome: number | null;
+  retirementYears: number | null;
+  targetMonthlyContrib: number | null;
+  targetInvestedAmount: number | null;
+  fiNumberManual: number | null;
+}
+
+export interface FireEssentialsResponse {
+  categories: {
+    id: string;
+    name: string;
+    color: string;
+    monthlyAvg: number;
+  }[];
+  totalEssentialMonthly: number;
+  liabilityCosts: {
+    wealthItemId: string;
+    wealthItemName: string;
+    categoryId: string;
+    categoryName: string;
+    categoryColor: string;
+    monthlyAvg: number;
+  }[];
+}
+
+export interface WealthItemSerialized {
+  id: string;
+  name: string;
+  value: number;
+  baseValue: number;
+  itemType: "ASSET" | "LIABILITY";
+  category: string;
+  appreciationRate: number | null;
+  appreciationStart: string;
+  rateFrequency: "MONTHLY" | "ANNUAL";
+  loanBank: string | null;
+  loanInstallments: number | null;
+  loanStartDate: string | null;
+  loanDueDay: number | null;
+  linkedCategoryId: string | null;
+  linkedCategoryName: string | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface WealthItemsResponse {
+  items: WealthItemSerialized[];
+  totalAssets: number;
+  totalLiabilities: number;
+  net: number;
+}
+
+export interface FinancialGoalSerialized {
+  id: string;
+  name: string;
+  targetAmount: number;
+  savedAmount: number;
+  contributionAmount: number;
+  contributionFrequency: "DAILY" | "WEEKLY" | "MONTHLY";
+  bank: string | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface FireScenario {
+  rate: number;
+  projectedMonths: number | null;
+  projectedYear: number | null;
+  projectionSeries: { month: number; value: number }[];
+}
+
+export interface FireResponse {
+  projectable: boolean;
+  reason?: string;
+  fiNumber?: number;
+  coastFireNumber?: number;
+  scenarios?: {
+    conservador: FireScenario;
+    moderado: FireScenario;
+    agressivo: FireScenario;
+  };
+  fiLine?: { month: number; value: number }[];
+  // Legacy fields (alias de moderado) — backward compat
+  projectedMonths?: number | null;
+  projectedYear?: number | null;
+  projectionSeries?: { month: number; value: number }[];
+  savingsRate?: number;
+  monthlyIncome?: number;
+  monthlyExpenses?: number;
+  monthlySurplus?: number;
+}


### PR DESCRIPTION
## Release v1.8.2 — Fixes pós-release

### Issues corrigidas
- Fix runtime error: tipos FIRE extraídos para `src/types/fire.ts` (client components importavam de API routes com `server-only`)
- Fix caminho da mensagem "Custo de Vida Real" → agora aponta para **Transações > Categorias**

### Infra
- `postinstall: prisma generate` adicionado para Vercel deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)