### PR TITLE
Release v2.0.0 - Painel de Proventos

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -262,6 +262,7 @@
     "tabs": {
       "portfolio": "المحفظة",
       "entries": "العمليات",
+      "proventos": "الأرباح",
       "intelligence": "الذكاء"
     },
     "summary": {
@@ -284,6 +285,24 @@
       "LCA": "LCA",
       "TESOURO": "الخزينة المباشرة",
       "POUPANCA": "مدخرات"
+    },
+    "proventos": {
+      "totalReceived": "المجموع المستلم",
+      "last6m": "آخر 6 أشهر",
+      "last12m": "آخر 12 شهرًا",
+      "last24m": "آخر 24 شهرًا",
+      "monthlyChart": "الأرباح الشهرية",
+      "byCategoryChart": "حسب الفئة",
+      "tableTitle": "الأرباح حسب الأصل",
+      "col": {
+        "asset": "الأصل",
+        "qty": "الكمية",
+        "avgCost": "متوسط التكلفة",
+        "yoc": "العائد على التكلفة",
+        "dy": "عائد الأرباح",
+        "lastDividend": "الأخير",
+        "total": "المجموع"
+      }
     },
     "entryTypes": {
       "PURCHASE": "شراء",

--- a/messages/en.json
+++ b/messages/en.json
@@ -262,6 +262,7 @@
     "tabs": {
       "portfolio": "Portfolio",
       "entries": "Transactions",
+      "proventos": "Dividends",
       "intelligence": "Intelligence"
     },
     "summary": {
@@ -284,6 +285,24 @@
       "LCA": "LCA",
       "TESOURO": "Treasury Direct",
       "POUPANCA": "Savings"
+    },
+    "proventos": {
+      "totalReceived": "Total Received",
+      "last6m": "Last 6 months",
+      "last12m": "Last 12 months",
+      "last24m": "Last 24 months",
+      "monthlyChart": "Monthly Dividends",
+      "byCategoryChart": "By Category",
+      "tableTitle": "Dividends by Asset",
+      "col": {
+        "asset": "Asset",
+        "qty": "Qty",
+        "avgCost": "Avg Cost",
+        "yoc": "YoC",
+        "dy": "DY",
+        "lastDividend": "Last",
+        "total": "Total Received"
+      }
     },
     "entryTypes": {
       "PURCHASE": "Purchase",

--- a/messages/es.json
+++ b/messages/es.json
@@ -262,6 +262,7 @@
     "tabs": {
       "portfolio": "Cartera",
       "entries": "Movimientos",
+      "proventos": "Dividendos",
       "intelligence": "Inteligencia"
     },
     "summary": {
@@ -284,6 +285,24 @@
       "LCA": "LCA",
       "TESOURO": "Tesoro Directo",
       "POUPANCA": "Ahorro"
+    },
+    "proventos": {
+      "totalReceived": "Total Recibido",
+      "last6m": "Últimos 6 meses",
+      "last12m": "Últimos 12 meses",
+      "last24m": "Últimos 24 meses",
+      "monthlyChart": "Dividendos Mensuales",
+      "byCategoryChart": "Por Categoría",
+      "tableTitle": "Dividendos por Activo",
+      "col": {
+        "asset": "Activo",
+        "qty": "Cant.",
+        "avgCost": "C.M.",
+        "yoc": "YoC",
+        "dy": "DY",
+        "lastDividend": "Último",
+        "total": "Total Recibido"
+      }
     },
     "entryTypes": {
       "PURCHASE": "Compra",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -262,6 +262,7 @@
     "tabs": {
       "portfolio": "Portefeuille",
       "entries": "Opérations",
+      "proventos": "Dividendes",
       "intelligence": "Intelligence"
     },
     "summary": {
@@ -284,6 +285,24 @@
       "LCA": "LCA",
       "TESOURO": "Trésor Direct",
       "POUPANCA": "Épargne"
+    },
+    "proventos": {
+      "totalReceived": "Total Reçu",
+      "last6m": "6 derniers mois",
+      "last12m": "12 derniers mois",
+      "last24m": "24 derniers mois",
+      "monthlyChart": "Dividendes Mensuels",
+      "byCategoryChart": "Par Catégorie",
+      "tableTitle": "Dividendes par Actif",
+      "col": {
+        "asset": "Actif",
+        "qty": "Qté",
+        "avgCost": "P.M.",
+        "yoc": "YoC",
+        "dy": "RD",
+        "lastDividend": "Dernier",
+        "total": "Total Reçu"
+      }
     },
     "entryTypes": {
       "PURCHASE": "Achat",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -262,6 +262,7 @@
     "tabs": {
       "portfolio": "पोर्टफोलियो",
       "entries": "लेनदेन",
+      "proventos": "लाभांश",
       "intelligence": "बुद्धिमत्ता"
     },
     "summary": {
@@ -284,6 +285,24 @@
       "LCA": "LCA",
       "TESOURO": "ट्रेजरी डायरेक्ट",
       "POUPANCA": "बचत"
+    },
+    "proventos": {
+      "totalReceived": "कुल प्राप्त",
+      "last6m": "पिछले 6 महीने",
+      "last12m": "पिछले 12 महीने",
+      "last24m": "पिछले 24 महीने",
+      "monthlyChart": "मासिक लाभांश",
+      "byCategoryChart": "श्रेणी अनुसार",
+      "tableTitle": "संपत्ति अनुसार लाभांश",
+      "col": {
+        "asset": "संपत्ति",
+        "qty": "मात्रा",
+        "avgCost": "औसत लागत",
+        "yoc": "YoC",
+        "dy": "DY",
+        "lastDividend": "अंतिम",
+        "total": "कुल"
+      }
     },
     "entryTypes": {
       "PURCHASE": "खरीद",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -263,6 +263,7 @@
     "tabs": {
       "portfolio": "Carteira",
       "entries": "Lançamentos",
+      "proventos": "Proventos",
       "intelligence": "Inteligência"
     },
     "summary": {
@@ -285,6 +286,24 @@
       "LCA": "LCA",
       "TESOURO": "Tesouro Direto",
       "POUPANCA": "Poupança"
+    },
+    "proventos": {
+      "totalReceived": "Total Recebido",
+      "last6m": "Últimos 6 meses",
+      "last12m": "Últimos 12 meses",
+      "last24m": "Últimos 24 meses",
+      "monthlyChart": "Proventos Mensais",
+      "byCategoryChart": "Por Categoria",
+      "tableTitle": "Proventos por Ativo",
+      "col": {
+        "asset": "Ativo",
+        "qty": "Qtd",
+        "avgCost": "P.M.",
+        "yoc": "YoC",
+        "dy": "DY",
+        "lastDividend": "Último",
+        "total": "Total Acumulado"
+      }
     },
     "entryTypes": {
       "PURCHASE": "Compra",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -262,6 +262,7 @@
     "tabs": {
       "portfolio": "投资组合",
       "entries": "交易记录",
+      "proventos": "股息",
       "intelligence": "智能分析"
     },
     "summary": {
@@ -284,6 +285,24 @@
       "LCA": "LCA",
       "TESOURO": "国库直购",
       "POUPANCA": "储蓄"
+    },
+    "proventos": {
+      "totalReceived": "累计收益",
+      "last6m": "近6个月",
+      "last12m": "近12个月",
+      "last24m": "近24个月",
+      "monthlyChart": "月度股息",
+      "byCategoryChart": "按类别",
+      "tableTitle": "按资产划分股息",
+      "col": {
+        "asset": "资产",
+        "qty": "数量",
+        "avgCost": "均价",
+        "yoc": "持股收益率",
+        "dy": "股息率",
+        "lastDividend": "最近",
+        "total": "累计"
+      }
     },
     "entryTypes": {
       "PURCHASE": "买入",

--- a/src/app/api/investments/proventos/route.ts
+++ b/src/app/api/investments/proventos/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { fetchDividends } from "@/lib/dividends";
+import type { ProventosData, ProventosAsset } from "@/components/investments/proventos/types";
+
+const BRAPI_ELIGIBLE = ["STOCK", "BDR", "ETF", "STOCK_INT"];
+
+function cutoffDate(months: number): Date {
+  const d = new Date();
+  d.setMonth(d.getMonth() - months);
+  return d;
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const assets = await prisma.asset.findMany({
+    where: { userId: session.user.id },
+    include: { entries: { orderBy: { date: "asc" } } },
+  });
+
+  const cutoff6m = cutoffDate(6);
+  const cutoff12m = cutoffDate(12);
+  const cutoff24m = cutoffDate(24);
+
+  let totalReceived = 0;
+  let last6m = 0;
+  let last12m = 0;
+  let last24m = 0;
+
+  const monthlyMap = new Map<string, number>();
+  const byCategoryMap = new Map<string, number>();
+  const proventosAssets: ProventosAsset[] = [];
+
+  for (const asset of assets) {
+    const dividendEntries = asset.entries.filter((e) => e.type === "DIVIDEND");
+    if (dividendEntries.length === 0) continue;
+
+    // Aggregate position data from PURCHASE/SALE entries
+    let totalQty = 0;
+    let totalCost = 0;
+    for (const e of asset.entries) {
+      const qty = parseFloat(String(e.quantity));
+      const price = parseFloat(String(e.price));
+      if (e.type === "PURCHASE") {
+        totalCost += qty * price;
+        totalQty += qty;
+      } else if (e.type === "SALE") {
+        if (totalQty > 0) {
+          const avgCostNow = totalCost / totalQty;
+          totalCost -= qty * avgCostNow;
+        }
+        totalQty -= qty;
+      } else if (e.type === "SPLIT") {
+        totalQty = qty;
+      }
+    }
+    if (totalQty < 0.000001) totalQty = 0;
+    const avgCost = totalQty > 0 ? totalCost / totalQty : 0;
+
+    // Dividend aggregations
+    let assetTotalDivs = 0;
+    let lastDividendDate: string | null = null;
+    let lastDividendAmount = 0;
+    let div12m = 0;
+
+    for (const e of dividendEntries) {
+      const amount = parseFloat(String(e.amount));
+      const entryDate = new Date(e.date);
+      assetTotalDivs += amount;
+
+      // Global KPIs
+      totalReceived += amount;
+      if (entryDate >= cutoff6m) last6m += amount;
+      if (entryDate >= cutoff12m) {
+        last12m += amount;
+        div12m += amount;
+      }
+      if (entryDate >= cutoff24m) last24m += amount;
+
+      // Monthly chart (last 13 months)
+      if (entryDate >= cutoffDate(13)) {
+        const key = `${entryDate.getFullYear()}-${String(entryDate.getMonth() + 1).padStart(2, "0")}`;
+        monthlyMap.set(key, (monthlyMap.get(key) ?? 0) + amount);
+      }
+
+      // By category
+      byCategoryMap.set(asset.type, (byCategoryMap.get(asset.type) ?? 0) + amount);
+
+      // Last dividend
+      if (!lastDividendDate || entryDate > new Date(lastDividendDate)) {
+        lastDividendDate = e.date.toISOString();
+        lastDividendAmount = amount;
+      }
+    }
+
+    const yieldOnCost =
+      totalQty > 0 && avgCost > 0 ? (div12m / (totalQty * avgCost)) * 100 : 0;
+
+    // DY from brapi (only for eligible tickers)
+    let dy: number | null = null;
+    if (asset.ticker && BRAPI_ELIGIBLE.includes(asset.type as string)) {
+      const cashDivs = await fetchDividends(asset.ticker);
+      if (cashDivs) {
+        const sum12m = cashDivs
+          .filter((d) => new Date(d.paymentDate) >= cutoff12m)
+          .reduce((s, d) => s + d.rate, 0);
+        const currentPrice = asset.currentPrice ? parseFloat(String(asset.currentPrice)) : 0;
+        dy = currentPrice > 0 ? (sum12m / currentPrice) * 100 : null;
+      }
+    }
+
+    proventosAssets.push({
+      id: asset.id,
+      name: asset.name,
+      ticker: asset.ticker,
+      type: asset.type,
+      totalQuantity: totalQty,
+      avgCost,
+      totalDividends: assetTotalDivs,
+      lastDividendDate,
+      lastDividendAmount,
+      yieldOnCost,
+      dy,
+    });
+  }
+
+  // Build monthly array (last 13 months, sorted)
+  const monthly = [...monthlyMap.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([month, amount]) => ({ month, amount }));
+
+  // Build byCategory array
+  const byCategory = [...byCategoryMap.entries()].map(([type, amount]) => ({
+    type: type as ProventosData["byCategory"][number]["type"],
+    amount,
+  }));
+
+  // Sort assets by totalDividends desc
+  proventosAssets.sort((a, b) => b.totalDividends - a.totalDividends);
+
+  const response: ProventosData = {
+    totalReceived,
+    last6m,
+    last12m,
+    last24m,
+    monthly,
+    byCategory,
+    assets: proventosAssets,
+  };
+
+  return NextResponse.json(response);
+}

--- a/src/components/investments/InvestmentsShell.tsx
+++ b/src/components/investments/InvestmentsShell.tsx
@@ -8,6 +8,7 @@ import { AssetList } from "./portfolio/AssetList";
 import { EntryList } from "./entries/EntryList";
 import { BenchmarkBar } from "./benchmarks/BenchmarkBar";
 import { IntelligenceTab } from "./intelligence/IntelligenceTab";
+import { ProventosTab } from "./proventos/ProventosTab";
 import type { AssetPosition } from "@/app/api/investments/portfolio/route";
 import type { AssetType } from "@/generated/prisma/client";
 import type { BenchmarkData } from "@/lib/benchmarks";
@@ -40,7 +41,7 @@ interface InvestmentsShellProps {
 
 export function InvestmentsShell({ initialCurrency, initialLocale }: InvestmentsShellProps) {
   const t = useTranslations("Investments");
-  const [activeTab, setActiveTab] = useState<"portfolio" | "entries" | "intelligence">("entries");
+  const [activeTab, setActiveTab] = useState<"portfolio" | "entries" | "proventos" | "intelligence">("entries");
   const [portfolioKey, setPortfolioKey] = useState(0);
   const [portfolioData, setPortfolioData] = useState<PortfolioData | null>(null);
   const [portfolioLoading, setPortfolioLoading] = useState(false);
@@ -50,7 +51,7 @@ export function InvestmentsShell({ initialCurrency, initialLocale }: Investments
 
   const triggerPortfolioRefresh = useCallback(() => setPortfolioKey((k) => k + 1), []);
 
-  function handleTabChange(tab: "entries" | "portfolio" | "intelligence") {
+  function handleTabChange(tab: "entries" | "portfolio" | "proventos" | "intelligence") {
     setActiveTab(tab);
     // Ao entrar na aba Carteira, recarregar para incluir ativos criados inline
     if (tab === "portfolio") triggerPortfolioRefresh();
@@ -93,7 +94,7 @@ export function InvestmentsShell({ initialCurrency, initialLocale }: Investments
       <div className="flex flex-col gap-3">
         <h1 className="text-xl font-semibold text-white">{t("title")}</h1>
         <div className="flex bg-axiom-hover rounded-lg p-1 gap-1 w-fit">
-        {(["entries", "portfolio", "intelligence"] as const).map((key) => (
+        {(["entries", "portfolio", "proventos", "intelligence"] as const).map((key) => (
           <button
             key={key}
             onClick={() => handleTabChange(key)}
@@ -145,6 +146,12 @@ export function InvestmentsShell({ initialCurrency, initialLocale }: Investments
             onEntryCreated={triggerPortfolioRefresh}
             onNewAsset={handleNewAsset}
           />
+        </div>
+      )}
+
+      {activeTab === "proventos" && (
+        <div className="mt-6">
+          <ProventosTab currency={initialCurrency} locale={initialLocale} />
         </div>
       )}
 

--- a/src/components/investments/proventos/ProventosChart.tsx
+++ b/src/components/investments/proventos/ProventosChart.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Bar, Doughnut } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  ArcElement,
+  type TooltipItem,
+} from "chart.js";
+import { formatCurrency } from "@/lib/utils";
+import type { AssetType } from "@/generated/prisma/client";
+import type { ProventosData } from "./types";
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend, ArcElement);
+
+const TYPE_COLORS: Partial<Record<AssetType, string>> = {
+  STOCK: "#FF6B35",
+  FII: "#F7931E",
+  ETF: "#FFB347",
+  BDR: "#FF8C42",
+  CRYPTO: "#A78BFA",
+  STOCK_INT: "#3B82F6",
+  OTHER: "#6B7280",
+  CDB: "#10B981",
+  RDB: "#059669",
+  LCI: "#34D399",
+  LCA: "#6EE7B7",
+  TESOURO: "#0EA5E9",
+  POUPANCA: "#94A3B8",
+  FIXED_INCOME: "#2DD4BF",
+};
+
+interface ProventosChartProps {
+  monthly: ProventosData["monthly"];
+  byCategory: ProventosData["byCategory"];
+  loading: boolean;
+  currency: string;
+  locale: string;
+}
+
+export function ProventosChart({ monthly, byCategory, loading, currency, locale }: ProventosChartProps) {
+  const [mounted, setMounted] = useState(false);
+  const t = useTranslations("Investments");
+
+  useEffect(() => setMounted(true), []);
+
+  if (loading || !mounted) {
+    return (
+      <div className="grid lg:grid-cols-2 gap-4">
+        <div className="bg-axiom-card border border-axiom-border rounded-xl p-5 animate-pulse">
+          <div className="h-4 bg-axiom-hover rounded w-1/3 mb-4" />
+          <div className="h-48 bg-axiom-hover rounded" />
+        </div>
+        <div className="bg-axiom-card border border-axiom-border rounded-xl p-5 animate-pulse">
+          <div className="h-4 bg-axiom-hover rounded w-1/3 mb-4" />
+          <div className="h-48 bg-axiom-hover rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  const barData = {
+    labels: monthly.map((m) => {
+      const [year, month] = m.month.split("-");
+      return new Date(parseInt(year), parseInt(month) - 1).toLocaleDateString(locale, {
+        month: "short",
+        year: "2-digit",
+      });
+    }),
+    datasets: [
+      {
+        label: t("proventos.monthlyChart"),
+        data: monthly.map((m) => m.amount),
+        backgroundColor: "#FF6B35cc",
+        borderColor: "#FF6B35",
+        borderWidth: 1,
+        borderRadius: 4,
+      },
+    ],
+  };
+
+  const barOptions = {
+    responsive: true,
+    animation: { duration: 1000, easing: "easeOutQuart" as const },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (ctx: TooltipItem<"bar">) =>
+            formatCurrency(ctx.parsed.y ?? 0, locale, currency),
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: { color: "#AAB2BD", font: { size: 11 } },
+        grid: { color: "#1E2D42" },
+      },
+      y: {
+        ticks: {
+          color: "#AAB2BD",
+          font: { size: 11 },
+          callback: (value: number | string) =>
+            typeof value === "number" ? formatCurrency(value, locale, currency) : value,
+        },
+        grid: { color: "#1E2D42" },
+      },
+    },
+  };
+
+  const donutLabels = byCategory.map((c) => {
+    try {
+      return t(`assetTypes.${c.type}`);
+    } catch {
+      return c.type;
+    }
+  });
+
+  const donutData = {
+    labels: donutLabels,
+    datasets: [
+      {
+        data: byCategory.map((c) => c.amount),
+        backgroundColor: byCategory.map((c) => `${TYPE_COLORS[c.type] ?? "#6B7280"}cc`),
+        borderColor: byCategory.map((c) => TYPE_COLORS[c.type] ?? "#6B7280"),
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const donutOptions = {
+    responsive: true,
+    animation: { duration: 1000, easing: "easeOutQuart" as const },
+    plugins: {
+      legend: {
+        position: "right" as const,
+        labels: { color: "#AAB2BD", font: { size: 12 }, padding: 12 },
+      },
+      tooltip: {
+        callbacks: {
+          label: (ctx: TooltipItem<"doughnut">) =>
+            formatCurrency(ctx.parsed, locale, currency),
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="grid lg:grid-cols-2 gap-4">
+      <div className="bg-axiom-card border border-axiom-border rounded-xl p-5">
+        <p className="text-sm font-medium text-white mb-4">{t("proventos.monthlyChart")}</p>
+        {monthly.length > 0 ? (
+          <Bar data={barData} options={barOptions} />
+        ) : (
+          <p className="text-axiom-muted text-sm text-center py-8">Sem dados mensais.</p>
+        )}
+      </div>
+      <div className="bg-axiom-card border border-axiom-border rounded-xl p-5">
+        <p className="text-sm font-medium text-white mb-4">{t("proventos.byCategoryChart")}</p>
+        {byCategory.length > 0 ? (
+          <Doughnut data={donutData} options={donutOptions} />
+        ) : (
+          <p className="text-axiom-muted text-sm text-center py-8">Sem dados por categoria.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/investments/proventos/ProventosKPIs.tsx
+++ b/src/components/investments/proventos/ProventosKPIs.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { TrendingUp } from "lucide-react";
+import { formatCurrency } from "@/lib/utils";
+import type { ProventosData } from "./types";
+
+const DURATION = 1000;
+function easeOutQuart(t: number) {
+  return 1 - Math.pow(1 - t, 4);
+}
+
+function useCountUp(target: number) {
+  const [current, setCurrent] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  const startRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    startRef.current = null;
+    function animate(ts: number) {
+      if (!startRef.current) startRef.current = ts;
+      const elapsed = ts - startRef.current;
+      const progress = Math.min(elapsed / DURATION, 1);
+      setCurrent(target * easeOutQuart(progress));
+      if (progress < 1) rafRef.current = requestAnimationFrame(animate);
+    }
+    rafRef.current = requestAnimationFrame(animate);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [target]);
+
+  return current;
+}
+
+interface ProventosKPIsProps {
+  data: Pick<ProventosData, "totalReceived" | "last6m" | "last12m" | "last24m"> | null;
+  loading: boolean;
+  currency: string;
+  locale: string;
+}
+
+function AnimatedCard({
+  label,
+  value,
+  currency,
+  locale,
+}: {
+  label: string;
+  value: number;
+  currency: string;
+  locale: string;
+}) {
+  const animated = useCountUp(value);
+  return (
+    <div className="bg-axiom-card border border-axiom-border rounded-xl p-5">
+      <div className="flex items-center gap-2 mb-2">
+        <TrendingUp size={16} className="text-axiom-income" />
+        <span className="text-axiom-muted text-sm">{label}</span>
+      </div>
+      <p className="text-xl font-semibold tabular-nums text-axiom-income">
+        {formatCurrency(animated, locale, currency)}
+      </p>
+    </div>
+  );
+}
+
+export function ProventosKPIs({ data, loading, currency, locale }: ProventosKPIsProps) {
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className="bg-axiom-card border border-axiom-border rounded-xl p-5 animate-pulse"
+          >
+            <div className="h-4 bg-axiom-hover rounded w-2/3 mb-3" />
+            <div className="h-7 bg-axiom-hover rounded w-1/2" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <p className="text-axiom-muted text-sm text-center py-8">
+        Nenhum provento registrado ainda.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <AnimatedCard label="Total Recebido" value={data.totalReceived} currency={currency} locale={locale} />
+      <AnimatedCard label="Últimos 6 meses" value={data.last6m} currency={currency} locale={locale} />
+      <AnimatedCard label="Últimos 12 meses" value={data.last12m} currency={currency} locale={locale} />
+      <AnimatedCard label="Últimos 24 meses" value={data.last24m} currency={currency} locale={locale} />
+    </div>
+  );
+}

--- a/src/components/investments/proventos/ProventosTab.tsx
+++ b/src/components/investments/proventos/ProventosTab.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ProventosData } from "./types";
+import { ProventosKPIs } from "./ProventosKPIs";
+import { ProventosChart } from "./ProventosChart";
+import { ProventosTable } from "./ProventosTable";
+
+interface ProventosTabProps {
+  currency: string;
+  locale: string;
+}
+
+export function ProventosTab({ currency, locale }: ProventosTabProps) {
+  const [data, setData] = useState<ProventosData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/investments/proventos")
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <ProventosKPIs data={data} loading={loading} currency={currency} locale={locale} />
+      <ProventosChart
+        monthly={data?.monthly ?? []}
+        byCategory={data?.byCategory ?? []}
+        loading={loading}
+        currency={currency}
+        locale={locale}
+      />
+      <ProventosTable
+        assets={data?.assets ?? []}
+        loading={loading}
+        currency={currency}
+        locale={locale}
+      />
+    </div>
+  );
+}

--- a/src/components/investments/proventos/ProventosTable.tsx
+++ b/src/components/investments/proventos/ProventosTable.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatCurrency } from "@/lib/utils";
+import type { AssetType } from "@/generated/prisma/client";
+import type { ProventosAsset } from "./types";
+
+const TYPE_COLORS: Partial<Record<AssetType, string>> = {
+  STOCK: "#FF6B35",
+  FII: "#F7931E",
+  ETF: "#FFB347",
+  BDR: "#FF8C42",
+  CRYPTO: "#A78BFA",
+  STOCK_INT: "#3B82F6",
+  OTHER: "#6B7280",
+  CDB: "#10B981",
+  RDB: "#059669",
+  LCI: "#34D399",
+  LCA: "#6EE7B7",
+  TESOURO: "#0EA5E9",
+  POUPANCA: "#94A3B8",
+  FIXED_INCOME: "#2DD4BF",
+};
+
+interface ProventosTableProps {
+  assets: ProventosAsset[];
+  loading: boolean;
+  currency: string;
+  locale: string;
+}
+
+function formatPct(value: number | null): string {
+  if (value === null || value === 0) return "—";
+  return `${value.toFixed(2)}%`;
+}
+
+function formatDate(isoDate: string | null, locale: string): string {
+  if (!isoDate) return "—";
+  return new Date(isoDate).toLocaleDateString(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "2-digit",
+  });
+}
+
+export function ProventosTable({ assets, loading, currency, locale }: ProventosTableProps) {
+  const t = useTranslations("Investments");
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+
+  const groups = useMemo(() => {
+    const map = new Map<AssetType, ProventosAsset[]>();
+    for (const a of assets) {
+      if (!map.has(a.type)) map.set(a.type, []);
+      map.get(a.type)!.push(a);
+    }
+    return [...map.entries()].sort((a, b) => {
+      const aTotal = a[1].reduce((s, x) => s + x.totalDividends, 0);
+      const bTotal = b[1].reduce((s, x) => s + x.totalDividends, 0);
+      return bTotal - aTotal;
+    });
+  }, [assets]);
+
+  function toggleGroup(type: string) {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-3">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-16 bg-axiom-card border border-axiom-border rounded-xl animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (assets.length === 0) {
+    return (
+      <div className="bg-axiom-card border border-axiom-border rounded-xl p-8 text-center">
+        <p className="text-axiom-muted text-sm">
+          Sem proventos registrados. Adicione lançamentos do tipo Dividendo.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="text-sm font-semibold text-white">{t("proventos.tableTitle")}</h2>
+      {groups.map(([type, groupAssets]) => {
+        const groupTotal = groupAssets.reduce((s, a) => s + a.totalDividends, 0);
+        const isCollapsed = collapsedGroups.has(type);
+        const color = TYPE_COLORS[type] ?? "#6B7280";
+
+        return (
+          <div
+            key={type}
+            className="bg-axiom-card border border-axiom-border rounded-xl overflow-hidden"
+          >
+            {/* Group Header */}
+            <button
+              onClick={() => toggleGroup(type)}
+              className="w-full flex items-center gap-4 px-5 py-3 hover:bg-axiom-hover transition-colors text-left"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold" style={{ color }}>
+                  {t(`assetTypes.${type}`)}
+                </p>
+                <p className="text-xs text-axiom-muted">
+                  {groupAssets.length} ativo{groupAssets.length !== 1 ? "s" : ""}
+                </p>
+              </div>
+              <div className="flex flex-col items-end min-w-[160px]">
+                <span className="text-sm font-semibold text-axiom-income">
+                  {formatCurrency(groupTotal, locale, currency)}
+                </span>
+                <span className="text-xs text-axiom-muted">total recebido</span>
+              </div>
+              {isCollapsed ? (
+                <ChevronDown size={16} className="text-axiom-muted flex-shrink-0" />
+              ) : (
+                <ChevronUp size={16} className="text-axiom-muted flex-shrink-0" />
+              )}
+            </button>
+
+            {/* Assets Table */}
+            {!isCollapsed && (
+              <div className="border-t border-axiom-border">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-axiom-border hover:bg-transparent">
+                      <TableHead className="text-axiom-muted text-xs">{t("proventos.col.asset")}</TableHead>
+                      <TableHead className="text-axiom-muted text-xs text-right">{t("proventos.col.qty")}</TableHead>
+                      <TableHead className="text-axiom-muted text-xs text-right">{t("proventos.col.avgCost")}</TableHead>
+                      <TableHead className="text-axiom-muted text-xs text-right">{t("proventos.col.yoc")}</TableHead>
+                      <TableHead className="text-axiom-muted text-xs text-right">{t("proventos.col.dy")}</TableHead>
+                      <TableHead className="text-axiom-muted text-xs text-right">{t("proventos.col.lastDividend")}</TableHead>
+                      <TableHead className="text-axiom-muted text-xs text-right">{t("proventos.col.total")}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {groupAssets.map((asset) => {
+                      const qty = asset.totalQuantity;
+                      const qtyDisplay = qty % 1 === 0 ? qty.toFixed(0) : qty.toFixed(4);
+                      return (
+                        <TableRow key={asset.id} className="border-axiom-border hover:bg-axiom-hover">
+                          {/* Ativo */}
+                          <TableCell className="py-2.5">
+                            <div className="flex items-center gap-2">
+                              <div
+                                className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0"
+                                style={{ backgroundColor: `${color}22`, color }}
+                              >
+                                {(asset.ticker ?? asset.name).slice(0, 2).toUpperCase()}
+                              </div>
+                              <div>
+                                <p className="text-sm font-medium text-white">
+                                  {asset.ticker ?? asset.name}
+                                </p>
+                                {asset.ticker && (
+                                  <p className="text-xs text-axiom-muted">{asset.name}</p>
+                                )}
+                              </div>
+                            </div>
+                          </TableCell>
+                          {/* Qtd */}
+                          <TableCell className="text-right text-sm text-white py-2.5">
+                            {qtyDisplay}
+                          </TableCell>
+                          {/* PM */}
+                          <TableCell className="text-right text-sm text-white py-2.5">
+                            {asset.avgCost > 0
+                              ? formatCurrency(asset.avgCost, locale, currency)
+                              : "—"}
+                          </TableCell>
+                          {/* YoC */}
+                          <TableCell className="text-right text-sm py-2.5">
+                            <span
+                              className={
+                                asset.yieldOnCost > 0
+                                  ? "text-axiom-income"
+                                  : "text-axiom-muted"
+                              }
+                            >
+                              {formatPct(asset.yieldOnCost)}
+                            </span>
+                          </TableCell>
+                          {/* DY */}
+                          <TableCell className="text-right text-sm py-2.5">
+                            <span
+                              className={
+                                asset.dy !== null && asset.dy > 0
+                                  ? "text-axiom-income"
+                                  : "text-axiom-muted"
+                              }
+                            >
+                              {formatPct(asset.dy)}
+                            </span>
+                          </TableCell>
+                          {/* Último Provento */}
+                          <TableCell className="text-right text-sm text-white py-2.5">
+                            <p>{formatDate(asset.lastDividendDate, locale)}</p>
+                            {asset.lastDividendAmount > 0 && (
+                              <p className="text-xs text-axiom-income">
+                                {formatCurrency(asset.lastDividendAmount, locale, currency)}
+                              </p>
+                            )}
+                          </TableCell>
+                          {/* Total Acumulado */}
+                          <TableCell className="text-right text-sm font-medium text-axiom-income py-2.5">
+                            {formatCurrency(asset.totalDividends, locale, currency)}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/investments/proventos/types.ts
+++ b/src/components/investments/proventos/types.ts
@@ -1,0 +1,25 @@
+import type { AssetType } from "@/generated/prisma/client";
+
+export interface ProventosAsset {
+  id: string;
+  name: string;
+  ticker: string | null;
+  type: AssetType;
+  totalQuantity: number;
+  avgCost: number;
+  totalDividends: number;
+  lastDividendDate: string | null;
+  lastDividendAmount: number;
+  yieldOnCost: number;
+  dy: number | null;
+}
+
+export interface ProventosData {
+  totalReceived: number;
+  last6m: number;
+  last12m: number;
+  last24m: number;
+  monthly: { month: string; amount: number }[];
+  byCategory: { type: AssetType; amount: number }[];
+  assets: ProventosAsset[];
+}

--- a/src/lib/dividends.ts
+++ b/src/lib/dividends.ts
@@ -1,0 +1,28 @@
+import { cached } from "./cache";
+
+const CACHE_TTL = 6 * 60 * 60 * 1000; // 6h
+
+export interface CashDividend {
+  paymentDate: string;
+  rate: number;
+  label: string; // "DIVIDENDO" | "JCP" | "RENDIMENTO"
+  lastDatePrior: string;
+}
+
+export async function fetchDividends(ticker: string): Promise<CashDividend[] | null> {
+  const token = process.env.BRAPI_TOKEN;
+  if (!token) return null;
+  return cached(`dividends:${ticker}`, CACHE_TTL, async () => {
+    try {
+      const res = await fetch(
+        `https://brapi.dev/api/quote/${ticker}?dividends=true&token=${token}`,
+        { cache: "no-store" }
+      );
+      if (!res.ok) return null;
+      const data = await res.json();
+      return (data.results?.[0]?.dividendsData?.cashDividends ?? null) as CashDividend[] | null;
+    } catch {
+      return null;
+    }
+  });
+}


### PR DESCRIPTION
## Release v2.0.0 - Painel de Proventos

### Resumo
Nova aba "Proventos" no módulo de Investimentos, exibindo histórico completo de dividendos, JCP e rendimentos. Dados primários dos lançamentos DIVIDEND + enriquecimento de DY via brapi.dev para ações.

### Issues Incluídas
- #135 types.ts + lib/dividends.ts — tipos e fetcher brapi (cache 6h)
- #136 API route GET /api/investments/proventos
- #137 ProventosKPIs — 4 cards animados (Total, 6m, 12m, 24m)
- #138 ProventosChart — Bar chart mensal + Donut por categoria
- #139 ProventosTable — Tabela colapsável por tipo com YoC e DY
- #140 ProventosTab + InvestmentsShell — integração da aba
- #141 i18n — 7 idiomas (pt-BR, en, es, fr, ar, zh, hi)

### Funcionalidades
- **KPIs animados:** Total Recebido, Últimos 6m, 12m e 24m com count-up easeOutQuart
- **Gráfico mensal:** barras dos últimos 13 meses de proventos
- **Gráfico donut:** distribuição por categoria de ativo (FII, Ações, Renda Fixa...)
- **Tabela por ativo:** Qtd, Preço Médio, Yield on Cost, DY, Último Provento, Total Acumulado
- **Grupos colapsáveis** por tipo de ativo, ordenados por total de proventos
- **DY via brapi.dev** para Ações (STOCK/BDR/ETF/STOCK_INT); fallback "—" para FIIs
- **YoC calculado do banco** para todos os ativos

🤖 Generated with [Claude Code](https://claude.com/claude-code)